### PR TITLE
fix(table): tolerate null scrollerParent in _getPaneScrollerArr after dispose

### DIFF
--- a/source/class/qx/test/ui/table/Table.js
+++ b/source/class/qx/test/ui/table/Table.js
@@ -266,6 +266,34 @@ qx.Class.define("qx.test.ui.table.Table", {
       tableModel.dispose();
     },
 
+    testGetPaneScrollerArrEmptyAfterDispose() {
+      var model = this.createModel();
+      var table = new qx.ui.table.Table(model);
+
+      table.destroy();
+      this.flush();
+      model.dispose();
+
+      // __scrollerParent is gone; the accessor must yield no scrollers, not throw.
+      this.assertArrayEquals([], table._getPaneScrollerArr());
+    },
+
+    testColumnModelReinitAfterDisposeDoesNotThrow() {
+      var model = this.createModel();
+      var table = new qx.ui.table.Table(model);
+
+      table.destroy();
+      this.flush();
+
+      // Reproduces the async-after-dispose path: getTableColumnModel re-creates
+      // the disposed column model, whose init() fires visibilityChanged ->
+      // _onColVisibilityChanged -> _getPaneScrollerArr. Must not throw on the
+      // nulled scroller parent.
+      table.getTableColumnModel();
+
+      model.dispose();
+    },
+
     testFocusAfterRemove() {
       var tableModelSimple = new qx.ui.table.model.Simple();
       tableModelSimple.setColumns(["Location", "Team"]);

--- a/source/class/qx/ui/table/Table.js
+++ b/source/class/qx/ui/table/Table.js
@@ -1123,7 +1123,12 @@ qx.Class.define("qx.ui.table.Table", {
      * @return {qx.ui.table.pane.Scroller[]} all TablePaneScrollers in this table.
      */
     _getPaneScrollerArr() {
-      return this.__scrollerParent.getChildren();
+      // __scrollerParent is null once the table has been disposed. An async
+      // callback that touches the table after disposal (e.g. getTableColumnModel
+      // lazily re-creating a disposed column model, whose init() fires
+      // visibilityChanged) can still reach here, so return no scrollers rather
+      // than throwing on null.
+      return this.__scrollerParent ? this.__scrollerParent.getChildren() : [];
     },
 
     /**


### PR DESCRIPTION
## Problem

`qx.ui.table.Table._getPaneScrollerArr()` is `return this.__scrollerParent.getChildren()`. `Table.destruct()` nulls `__scrollerParent` (via `_disposeObjects`). An async callback that touches the table **after disposal** can still reach `_getPaneScrollerArr` and throw:

```
TypeError: Cannot read properties of null (reading 'getChildren')
    at _getPaneScrollerArr
    at _onColVisibilityChanged
    ...
    at <columnModel>.init
    at getTableColumnModel
```

The path: code awaits an RPC, the table is disposed in the meantime, then the continuation calls `getTableColumnModel()`. Because `destruct` also nulled `__columnModel`, the getter **lazily re-creates** the column model, whose `init()` synchronously fires `visibilityChanged` → `_onColVisibilityChanged` → `_getPaneScrollerArr()` → `null.getChildren()`. Since it throws during synchronous event dispatch, it escapes the caller's try/catch as an unhandled rejection.

This is a generic robustness gap: any deferred work that reaches the table after disposal hits it. We saw it in a downstream app (a data tree closed while its columns were still loading), but the fix belongs here since `_getPaneScrollerArr` is called from ~20 sites and `_onColVisibilityChanged` / `_updateScrollerWidths` / `_updateScrollBarVisibility` all already tolerate an empty array.

## Fix

Return an empty scroller array when `__scrollerParent` is null:

```js
_getPaneScrollerArr() {
  return this.__scrollerParent ? this.__scrollerParent.getChildren() : [];
}
```

All existing callers either iterate the result (empty → no-op) or index it (`getPaneScroller` already returned `undefined` for out-of-range), so an empty array is safe.

## Tests

Added to `qx.test.ui.table.Table`:
- `testGetPaneScrollerArrEmptyAfterDispose` — after `destroy()` + flush, `_getPaneScrollerArr()` returns `[]` instead of throwing.
- `testColumnModelReinitAfterDisposeDoesNotThrow` — reproduces the real path: after dispose, `getTableColumnModel()` (which re-inits and fires `visibilityChanged`) completes without throwing.

Both follow the existing `Table.js` / `Dispose.js` patterns (`LayoutTestCase`, `destroy()` + `this.flush()`; calling the protected `_getPaneScrollerArr()` directly, as `testSpecialListener` already does).